### PR TITLE
Faiss xb update and other small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,12 @@ CUDA_VISIBLE_DEVICES=0 python -m income.jpq.train_gpl \
     --model_save_dir "./final_models/${dataset}/gpl" \
     --init_backbone "distilbert"\
     --log_dir "./logs/${dataset}/log" \
-    --init_index_path "./init/${dataset}/OPQ32,IVF1,PQ32x8.index" \
+    --init_index_path "./init/${dataset}/OPQ96,IVF1,PQ96x8.index" \
     --init_model_path "sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco" \
     --data_path "./datasets/${dataset}" \
     --cross_encoder "cross-encoder/ms-marco-MiniLM-L-6-v2" \
     --lambda_cut 200 \
+    --gpu_search \
     --centroid_lr 1e-4 \
     --train_batch_size 32 \
     --num_train_epochs 2 \

--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ CUDA_VISIBLE_DEVICES=0 python -m income.jpq.train_gpl \
     --data_path "./datasets/${dataset}" \
     --cross_encoder "cross-encoder/ms-marco-MiniLM-L-6-v2" \
     --lambda_cut 200 \
-    --gpu_search \
     --centroid_lr 1e-4 \
     --train_batch_size 32 \
     --num_train_epochs 2 \
+    --gpu_search \
     --max_seq_length 64 \
     --loss_neg_topK 25
 ```

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ export PREFIX="gen"
 python -m income.jpq.beir.transform \
           --dataset ${dataset} \
           --output_dir "./datasets/${dataset}" \
-          --prefix  ${PREFIX} \
+          --prefix  ${PREFIX}
 ```
 2. Preprocessing Script tokenizes the queries and corpus
 ```bash

--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ CUDA_VISIBLE_DEVICES=0 python -m income.jpq.init \
 CUDA_VISIBLE_DEVICES=0 python -m income.jpq.train_gpl \
     --preprocess_dir "./preprocessed/${dataset}" \
     --model_save_dir "./final_models/${dataset}/gpl" \
+    --init_backbone "distilbert"\
     --log_dir "./logs/${dataset}/log" \
-    --init_index_path "./init/${dataset}/OPQ96,IVF1,PQ96x8.index" \
+    --init_index_path "./init/${dataset}/OPQ32,IVF1,PQ32x8.index" \
     --init_model_path "sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco" \
     --data_path "./datasets/${dataset}" \
     --cross_encoder "cross-encoder/ms-marco-MiniLM-L-6-v2" \
@@ -165,7 +166,6 @@ CUDA_VISIBLE_DEVICES=0 python -m income.jpq.train_gpl \
     --centroid_lr 1e-4 \
     --train_batch_size 32 \
     --num_train_epochs 2 \
-    --gpu_search \
     --max_seq_length 64 \
     --loss_neg_topK 25
 ```

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ python -m income.jpq.models.jpqtower_converter \
         --doc_encoder_model "sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco" \
         --query_faiss_index "./final_models/${dataset}/genq/epoch-1/OPQ96,IVF1,PQ96x8.index" \
         --doc_faiss_index "./init/${dataset}/OPQ96,IVF1,PQ96x8.index" \
-        --model_output_dir "./jpqtower/${dataset}/"
+        --model_output_dir "./jpqtower/${dataset}/"\
+        --backbone "distilbert"
 ```
 ### Inference
 ```python

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ CUDA_VISIBLE_DEVICES=0 python -m income.jpq.preprocess \
 ```bash
 CUDA_VISIBLE_DEVICES=0 python -m income.jpq.init \
   --preprocess_dir "./preprocessed/${dataset}" \
-  --model_dir "sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco"
+  --model_dir "sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco" \
+  --backbone "distilbert"\
   --max_doc_length 350 \
   --output_dir "./init/${dataset}" \
   --subvector_num 96

--- a/income/jpq/init.py
+++ b/income/jpq/init.py
@@ -34,7 +34,7 @@ def prediction(
     test_dataloader = DataLoader(
         test_dataset,
         sampler=SequentialSampler(test_dataset),
-        batch_size=eval_batch_size*n_gpu,
+        batch_size=eval_batch_size*n_gpu if n_gpu > 0 else eval_batch_size,
         collate_fn=data_collator,
         drop_last=False,
     )

--- a/income/jpq/init.py
+++ b/income/jpq/init.py
@@ -132,30 +132,37 @@ def init(
     doc_embeddings = doc_embeddings.reshape(-1, doc_embed_size)
     
     save_index_path = os.path.join(output_dir, f"OPQ{subvector_num},IVF1,PQ{subvector_num}x8.index")
-    res = faiss.StandardGpuResources()
-    
-    res.setTempMemory(1024*1024*512)
-    co = faiss.GpuClonerOptions()
-    co.useFloat16 = subvector_num >= 56
-    co.verbose = True
+    if n_gpu > 0:
+        # Set up for GPU only if available
+        res = faiss.StandardGpuResources()
+        res.setTempMemory(1024*1024*512)
+        co = faiss.GpuClonerOptions()
+        co.useFloat16 = subvector_num >= 56
+        co.verbose = True
 
-    # faiss.omp_set_num_threads(6)
+    # Common setup for CPU and GPU
     dim = doc_embed_size
-    index = faiss.index_factory(dim, 
-        f"OPQ{subvector_num},IVF1,PQ{subvector_num}x8", faiss.METRIC_INNER_PRODUCT)
+    index = faiss.index_factory(dim,
+                                f"OPQ{subvector_num},IVF1,PQ{subvector_num}x8",
+                                faiss.METRIC_INNER_PRODUCT)
     index.verbose = True
-    index = faiss.index_cpu_to_gpu(res, 0, index, co)    
+
+    if n_gpu > 0:
+        index = faiss.index_cpu_to_gpu(res, 0, index, co)
+
     logger.info("Starting to train faiss index on document embeddings!")
     assert not index.is_trained
     index.train(doc_embeddings)
     logger.info("Starting to index document embeddings!")
     assert index.is_trained
     index.add(doc_embeddings)
-    logger.info("Converting indexes from GPU to CPU!")
-    index = faiss.index_gpu_to_cpu(index)
-    logger.info("Saving index to CPU memory: {}".format(save_index_path))
-    faiss.write_index(index, save_index_path)
 
+    if n_gpu > 0:
+        logger.info("Converting indexes from GPU to CPU!")
+        index = faiss.index_gpu_to_cpu(index)
+
+    logger.info(f"Saving index to CPU memory: {save_index_path}")
+    faiss.write_index(index, save_index_path)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/income/jpq/models/jpqtower_converter.py
+++ b/income/jpq/models/jpqtower_converter.py
@@ -40,8 +40,11 @@ def convert_to_jpqtower(query_encoder_model, doc_encoder_model, query_faiss_inde
         centroid_embeds = faiss.vector_to_array(ivf_index.pq.centroids)
         centroid_embeds = centroid_embeds.reshape(ivf_index.pq.M, ivf_index.pq.ksub, ivf_index.pq.dsub)
         coarse_quantizer = faiss.downcast_index(ivf_index.quantizer)
-        coarse_embeds = faiss.vector_to_array(coarse_quantizer.xb)
-        centroid_embeds += coarse_embeds.reshape(ivf_index.pq.M, -1, ivf_index.pq.dsub)
+        #.xb attribute was depreciated
+        #coarse_embeds = faiss.vector_to_array(coarse_quantizer.xb)
+        #centroid_embeds += coarse_embeds.reshape(ivf_index.pq.M, -1, ivf_index.pq.dsub)
+        coarse_embeds = faiss.rev_swig_ptr(coarse_quantizer.get_xb(), coarse_quantizer.ntotal * coarse_quantizer.d)
+        coarse_embeds = coarse_embeds.reshape(coarse_quantizer.ntotal, coarse_quantizer.d)
         coarse_embeds[:] = 0   
 
         if backbone == "distilbert":

--- a/income/jpq/preprocess.py
+++ b/income/jpq/preprocess.py
@@ -325,7 +325,7 @@ def get_arguments():
     parser.add_argument(
         "--tokenizer",
         type=str,
-        required=True,
+        required=False,
         help="tokenizer to use for encoding, default: sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco",
     )
     parser.add_argument(
@@ -337,7 +337,7 @@ def get_arguments():
     parser.add_argument("--threads", type=int, default=32)
 
     args = parser.parse_args()
-
+    args.tokenizer = "sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco" if args.tokenizer == '' else args.tokenizer
     return args
 
 if __name__ == '__main__':

--- a/income/jpq/preprocess.py
+++ b/income/jpq/preprocess.py
@@ -337,7 +337,7 @@ def get_arguments():
     parser.add_argument("--threads", type=int, default=32)
 
     args = parser.parse_args()
-    args.tokenizer = "sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco" if args.tokenizer == '' else args.tokenizer
+    args.tokenizer = "sebastian-hofstaetter/distilbert-dot-tas_b-b256-msmarco" if args.tokenizer == None else args.tokenizer
     return args
 
 if __name__ == '__main__':

--- a/income/jpq/train_gpl.py
+++ b/income/jpq/train_gpl.py
@@ -122,7 +122,6 @@ def compute_loss(query_embeddings, pq_codes, centroids,
         rel_scores = cur_top_scores[target_labels]
         irrel_scores = cur_top_scores[~target_labels]
         pair_diff = rel_scores - irrel_scores
-
         query, docs = queries[qid], [corpus[doc_id] for doc_id in retrieve_pids.tolist()]
         scores_ce = cross_encoder.predict(
             [(query, x) for x in docs], 

--- a/income/jpq/train_gpl.py
+++ b/income/jpq/train_gpl.py
@@ -4,7 +4,8 @@ from .models.backbones.roberta_tokenizer import RobertaTokenizer
 
 from torch.utils.tensorboard import SummaryWriter
 from torch.utils.data import DataLoader, RandomSampler
-from transformers import (AdamW, get_linear_schedule_with_warmup,
+from torch.optim import AdamW
+from transformers import (get_linear_schedule_with_warmup,
     RobertaConfig, AutoConfig, AutoTokenizer)
 from sentence_transformers import CrossEncoder
 
@@ -120,8 +121,13 @@ def compute_loss(query_embeddings, pq_codes, centroids,
         cur_top_scores = (qembedding.reshape(1, -1) * psg_embeddings).sum(-1)
         rel_scores = cur_top_scores[target_labels]
         irrel_scores = cur_top_scores[~target_labels]
-        pair_diff = rel_scores - irrel_scores
         
+        # This line gives an error because rel_scores and irrel_scores are different sizes
+        # i.e. there are more irrelevant than relevant passages retrieved
+        # pair_diff = rel_scores - irrel_scores
+        # Instead let's calc the piecewise difference, which will result in a tensor of size [p+, p-]
+        pair_diff = rel_scores[:, None] - irrel_scores[None, :]
+
         query, docs = queries[qid], [corpus[doc_id] for doc_id in retrieve_pids.tolist()]
         scores_ce = cross_encoder.predict(
             [(query, x) for x in docs], 
@@ -132,7 +138,8 @@ def compute_loss(query_embeddings, pq_codes, centroids,
         )
         rel_ce_scores = scores_ce[target_labels]
         irrel_ce_scores = scores_ce[~target_labels]
-        labels = rel_ce_scores - irrel_ce_scores
+        # Once doing piecewise difference
+        labels = rel_ce_scores[:,None] - irrel_ce_scores[None,:]
         cur_loss = loss_function(pair_diff, labels)
         loss += cur_loss
 
@@ -173,7 +180,7 @@ def train(args, model, pq_codes, centroid_embeds, opq_transform, opq_index, toke
         {'params': [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)], 'weight_decay': 0.0},
         {'params': [centroid_embeds], 'weight_decay': args.centroid_weight_decay, 'lr': args.centroid_lr},
     ]
-    optimizer = AdamW(optimizer_grouped_parameters, lr=args.lr, eps=args.adam_epsilon)
+    optimizer = AdamW(params = optimizer_grouped_parameters, lr=args.lr, eps=args.adam_epsilon)
     scheduler = get_linear_schedule_with_warmup(
         optimizer, num_warmup_steps=args.warmup_steps,
         num_training_steps=t_total)
@@ -290,7 +297,7 @@ def run_parse_args():
     
     parser.add_argument("--lambda_cut", type=int, required=True)
     parser.add_argument("--centroid_lr", type=float, required=True)
-    parser.add_argument("--gpu_search", action="store_true")
+    parser.add_argument("--gpu_search",  action='store_true')
     parser.add_argument("--centroid_weight_decay", type=float, default=0)
 
     parser.add_argument("--loss_neg_topK", type=int, default=200)
@@ -322,7 +329,7 @@ def train_gpl(args):
 
     # Setup CUDA, GPU 
     args.model_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    args.n_gpu = 1
+    args.n_gpu = 0
 
     logger.warning("Model Device: %s, n_gpu: %s", args.model_device, args.n_gpu)
 
@@ -371,11 +378,17 @@ def train_gpl(args):
     centroid_embeds = faiss.vector_to_array(ivf_index.pq.centroids)
     centroid_embeds = centroid_embeds.reshape(ivf_index.pq.M, ivf_index.pq.ksub, ivf_index.pq.dsub)
     coarse_quantizer = faiss.downcast_index(ivf_index.quantizer)
-    coarse_embeds = faiss.vector_to_array(coarse_quantizer.xb)
-    centroid_embeds += coarse_embeds.reshape(ivf_index.pq.M, -1, ivf_index.pq.dsub)
+    # the .xb attribute was depreciated in FAISS
+    #coarse_embeds = faiss.vector_to_array(coarse_quantizer.xb)
+    #centroid_embeds += coarse_embeds.reshape(ivf_index.pq.M, -1, ivf_index.pq.dsub)
+    coarse_embeds = faiss.rev_swig_ptr(
+            coarse_quantizer.get_xb(), coarse_quantizer.ntotal * coarse_quantizer.d
+        )
+    coarse_embeds = coarse_embeds.reshape(coarse_quantizer.ntotal, coarse_quantizer.d)
     faiss.copy_array_to_vector(centroid_embeds.ravel(), ivf_index.pq.centroids)
-    coarse_embeds[:] = 0   
-    faiss.copy_array_to_vector(coarse_embeds.ravel(), coarse_quantizer.xb)
+    coarse_embeds[:] = 0
+    #faiss.copy_array_to_vector(coarse_embeds.ravel(), coarse_quantizer.xb)
+    coarse_quantizer.add(coarse_embeds)
 
     centroid_embeds = torch.FloatTensor(centroid_embeds).to(args.model_device)
     centroid_embeds.requires_grad = True

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'transformers >= 4.3.3',
         'tensorboard >= 2.5.0',
         'beir',
-        'datasets'
+        'datasets',
+        'boto3'
     ],
     keywords="Information Retrieval Transformer Networks BERT PyTorch IR NLP deep learning"
 )


### PR DESCRIPTION
The latest version of faiss depreciated the .xb attribute, causing errors when training & converting JPQ models. This PR replaces instances of:
```py
coarse_embeds = faiss.vector_to_array(coarse_quantizer.xb)
centroid_embeds += coarse_embeds.reshape(ivf_index.pq.M, -1, ivf_index.pq.dsub)
```

with 
```py
coarse_embeds = faiss.rev_swig_ptr(coarse_quantizer.get_xb(), coarse_quantizer.ntotal * coarse_quantizer.d)
coarse_embeds = coarse_embeds.reshape(coarse_quantizer.ntotal, coarse_quantizer.d)
```

Additionally, I added a few small changes for quality of life and for running on systems without GPU:
* Added missing newline '\' chars in the readme bash scripts
* Added boto3 to the requirements in setup.py
* Added behavior for a default tokenizer
* Removed the depreciating transformers AdamW optimizer and replaced it with pytorch AdamW
